### PR TITLE
Support PreDeployInProgress status

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9922,6 +9922,7 @@ var DeployStatus;
     DeployStatus["Created"] = "created";
     DeployStatus["BuildInProgress"] = "build_in_progress";
     DeployStatus["UpdateInProgress"] = "update_in_progress";
+    DeployStatus["PreDeployInProgress"] = "pre_deploy_in_progress";
     DeployStatus["Live"] = "live";
     DeployStatus["Deactivated"] = "deactivated";
     DeployStatus["Build_failed"] = "build_failed";
@@ -10013,6 +10014,7 @@ const waitForDeployment = (apiKey, serviceId, deployId) => wait_for_deployment_a
         DeployStatus.Created,
         DeployStatus.BuildInProgress,
         DeployStatus.UpdateInProgress,
+        DeployStatus.PreDeployInProgress,
     ];
     while (inProgressStatusCodes.includes(status)) {
         core.info(`Waiting for deployment ${deployId} to finish processing... (${status})`);

--- a/src/check-deploy-status.ts
+++ b/src/check-deploy-status.ts
@@ -4,6 +4,7 @@ export enum DeployStatus {
   Created = "created",
   BuildInProgress = "build_in_progress",
   UpdateInProgress = "update_in_progress",
+  PreDeployInProgress = "pre_deploy_in_progress",
   Live = "live",
   Deactivated = "deactivated",
   Build_failed = "build_failed",

--- a/src/wait-for-deployment.ts
+++ b/src/wait-for-deployment.ts
@@ -13,6 +13,7 @@ export const waitForDeployment = async (apiKey: string, serviceId: string, deplo
     DeployStatus.Created,
     DeployStatus.BuildInProgress,
     DeployStatus.UpdateInProgress,
+    DeployStatus.PreDeployInProgress,
   ];
   while (inProgressStatusCodes.includes(status)) {
     core.info(`Waiting for deployment ${deployId} to finish processing... (${status})`);


### PR DESCRIPTION
This PR adds support for [Render's new "Pre-deploy command" feature](https://render.com/blog/build-pipeline). Without that our workflows fail with the following error sometimes:

```
Error: Deployment failed: Unsuccessful deployment status: pre_deploy_in_progress
```

P.S. Thank you for the great workflow!