### PR TITLE
Update Node version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
   success:
     description: 'A boolean indicaating if the deployment was successful or not'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: upload-cloud


### PR DESCRIPTION
Hi, thanks for this very useful action!

I am currently getting this message as a warning in my flows:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: `bankfliptech/deploy-to-render@v1`. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

so I figured I'd make a PR to update the version. However I'm not sure how to test it, and whether any other change is needed, so do let me know if there's another step missing. Cheers!
